### PR TITLE
feat: add notification support

### DIFF
--- a/src/components/molecules/TimerControls/TimerControls.tsx
+++ b/src/components/molecules/TimerControls/TimerControls.tsx
@@ -3,12 +3,14 @@ import styles from './TimerControls.module.css';
 import { Button } from '../../atoms/Button/Button';
 import { usePomodoroContext } from '../../../context/PomodoroContext';
 import { playStartSound } from '../../../utils/sound';
+import { requestNotificationPermission } from '../../../utils/notifications';
 
 export const TimerControls: React.FC = () => {
   const { isRunning, setIsRunning, tasks, setActiveTaskId } = usePomodoroContext();
 
   const handleStartPause = () => {
     if (!isRunning) {
+      requestNotificationPermission();
       playStartSound();
 
       const firstUnfinished = tasks.find((task) => task.completedPomodoros < task.pomodoros);

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -64,6 +64,15 @@ export const useTimer = () => {
             alarmPlayedRef.current = true;
           }
 
+          if (Notification.permission === 'granted') {
+            new Notification("Time's up!", {
+              body:
+                mode === 'pomodoro'
+                  ? 'Take a short break!'
+                  : 'Ready to focus? Start your next Pomodoro!',
+            });
+          }
+
           if (!pomodoroHandledRef.current && mode === 'pomodoro') {
             incrementCompletedPomodoros();
             pomodoroHandledRef.current = true;

--- a/src/utils/notifications.test.ts
+++ b/src/utils/notifications.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, vi, beforeEach, afterEach, expect, Mock } from 'vitest';
+
+let requestNotificationPermission: typeof import('./notifications').requestNotificationPermission;
+
+describe('requestNotificationPermission', () => {
+  let originalNotification: typeof globalThis.Notification;
+  let requestPermissionMock: Mock;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    requestNotificationPermission = (await import('./notifications')).requestNotificationPermission;
+
+    originalNotification = globalThis.Notification;
+
+    requestPermissionMock = vi.fn().mockResolvedValue('granted');
+
+    globalThis.Notification = {
+      requestPermission: requestPermissionMock,
+      permission: 'default',
+    } as unknown as typeof Notification;
+  });
+
+  afterEach(() => {
+    globalThis.Notification = originalNotification;
+  });
+
+  it('calls Notification.requestPermission once and sets requested flag', async () => {
+    await requestNotificationPermission();
+    expect(requestPermissionMock).toHaveBeenCalledTimes(1);
+
+    await requestNotificationPermission();
+    expect(requestPermissionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning when permission is denied', async () => {
+    requestPermissionMock.mockResolvedValueOnce('denied');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await requestNotificationPermission();
+
+    expect(warnSpy).toHaveBeenCalledWith('Notification permission denied');
+    warnSpy.mockRestore();
+  });
+
+  it('does nothing if Notification is not in window', async () => {
+    // @ts-expect-error intentionally removing for test
+    delete globalThis.Notification;
+
+    await expect(requestNotificationPermission()).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,11 @@
+let requested = false;
+
+export const requestNotificationPermission = async () => {
+  if (requested || !('Notification' in window)) return;
+  requested = true;
+
+  const result = await Notification.requestPermission();
+  if (result !== 'granted') {
+    console.warn('Notification permission denied');
+  }
+};


### PR DESCRIPTION
# 📝 Pull Request

> Thank you for contributing to Pomodoro! Please review the checklist and provide any relevant information.

---

## 📌 PR Summary

**Type:** Feature
**Scope:** Notification
**Branch:** `feature/add-notification-support` → `develop`

> This PR adds support for desktop notifications. When the timer ends and notification permission has been granted, a native browser notification is shown to the user. This enhances the user experience by providing a visual alert even if the tab is not in focus.

---

## ✅ Checklist

- [x] My branch is up to date with `develop`
- [x] I’ve followed the [branch naming conventions](../blob/develop/CONTRIBUTING.md#branch-naming-conventions)
- [x] Lint passes (`yarn lint`)
- [x] Tests pass (`yarn test`)
- [x] New features or logic are tested
- [ ] Added/updated Storybook stories (if applicable)
- [ ] Added/updated README or CONTRIBUTING (if docs changed)
- [x] No `console.log`, `console.error`, or `TODO` comments remain

---

## 🧪 What’s Covered?

> 	•	Added requestNotificationPermission utility function
	•	Updated useTimer to trigger a notification when timer ends
	•	Mocked and tested Notification API in unit tests
	•	Ensured permission is requested only once per session

---

## 📸 Screenshots (optional)

> N/A 

---

## 📂 Related Issues or Discussions

N/A 

---

Thanks again! 🎉
